### PR TITLE
Set a default CRAN in R profile

### DIFF
--- a/.Rprofile
+++ b/.Rprofile
@@ -7,7 +7,7 @@ if (file.exists("~/.Rprofile")) {
 
 options(
   repos = c(
-    gsub('^@CRAN@$', 'https://cloud.r-project.org', getOption('repos')),
+    gsub('^@CRAN@$', 'https://cloud.r-project.org', getOption('repos', c(CRAN = "@CRAN@"))),
     CRANextra = if (Sys.info()["sysname"] == "Darwin") 'https://macos.rbind.io'
   ),
   Ncpus = 10, mc.cores = 10, browser = 'false',


### PR DESCRIPTION
Otherwise, it does not work on my side. 

I don't set `options(repos)` and it seems it is empty in the Rprofile. Not yet filled with `@CRAN@`. 
I wasn't expecting that but here is what I get if I put this in the `.Rprofile`

```
cat("Is repo set in R .profile ?\n")
cat("Repos is: ")
getOption("repos")
```

```
Restarting R session...

Is repo set in R .profile ?
NULL
```

I don't think this would have an impact to you. Opening PR to avoid breaking something 😅 
